### PR TITLE
Switch daterange width to be expressed in ems and scale to fit. 

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -185,7 +185,7 @@ img.details-chart {
 }
 
 .daterange {
-	width: 275px;
+	width: 30em;
 	float: right;
 }
 

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -185,7 +185,7 @@ img.details-chart {
 }
 
 .daterange {
-	width: 30em;
+	width: 29em;
 	float: right;
 }
 


### PR DESCRIPTION
Switches daterange styling to be 30em rather than 275px. Fixes #13

NOTE: This PR only includes the source .css file - and *NOT* the minified version of the file since I'm not sure how you're generating that. So that will need rebuilt after this PR is merged.