### PR TITLE
Use standard EDD functions for number formatting. Fixes #14

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -195,22 +195,22 @@
       case 'revenue':
           // do revenue
 
-          $('#revenue-6mocompare span').text( data.earnings.detail.sixmoago.compare + eddm.compare_temp_2 ).removeClass().addClass( data.earnings.detail.sixmoago.classes );
-          $('.detail-compare-second').text( data.earnings.detail.sixmoago.total );
+          $('#revenue-6mocompare span').html( data.earnings.detail.sixmoago.compare + eddm.compare_temp_2 ).removeClass().addClass( data.earnings.detail.sixmoago.classes );
+          $('.detail-compare-second').html( data.earnings.detail.sixmoago.total );
 
-          $('.detail-compare-third').text( data.earnings.detail.twelvemoago.total );
-          $('#revenue-12mocompare span').text( data.earnings.detail.twelvemoago.compare + eddm.compare_temp_2 ).removeClass().addClass( data.earnings.detail.twelvemoago.classes );
+          $('.detail-compare-third').html( data.earnings.detail.twelvemoago.total );
+          $('#revenue-12mocompare span').html( data.earnings.detail.twelvemoago.compare + eddm.compare_temp_2 ).removeClass().addClass( data.earnings.detail.twelvemoago.classes );
 
-          $('#earnings-today h2').text( data.earnings.detail.today );
-          $('#earnings-this-month h2').text( data.earnings.detail.this_month );
+          $('#earnings-today h2').html( data.earnings.detail.today );
+          $('#earnings-this-month h2').html( data.earnings.detail.this_month );
 
-          $('#renewal-rate h2').text( data.yearly_renewal_rate.percent + '%' );
-          $('#yearly-renewal-compare span').text( 'Last ' + data.yearly_renewal_rate.period + ' days' );
+          $('#renewal-rate h2').html( data.yearly_renewal_rate.percent + '%' );
+          $('#yearly-renewal-compare span').html( 'Last ' + data.yearly_renewal_rate.period + ' days' );
 
-          $('#box-5 .bottom-text span').text( data.earnings.detail.sixmoago.compare + '%' );
-          $('.detail-compare-second').text( data.earnings.detail.sixmoago.total );
+          $('#box-5 .bottom-text span').html( data.earnings.detail.sixmoago.compare + '%' );
+          $('.detail-compare-second').html( data.earnings.detail.sixmoago.total );
 
-          $('.detail-compare-third').text( data.earnings.detail.twelvemoago.total );
+          $('.detail-compare-third').html( data.earnings.detail.twelvemoago.total );
 
           break;
       case 'renewals':

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -3,7 +3,6 @@
   var eddm = {};
 
   eddm.init = function() {
-    eddm.currencySign = window.edd_vars.currency_sign;
     eddm.compare_temp_2 = window.eddMetrics.compare_string_2;
     eddm.revenue = window.eddMetrics.revenue;
     eddm.downloads = window.eddMetrics.downloads;
@@ -106,18 +105,18 @@
 
     var compareTemp = window.eddMetrics.compare_string + ' ' + data.dates.num_days + ' ' + window.eddMetrics.days;
 
-    $('#revenue').html( eddm.currencySign + data.earnings.total );
+    $('#revenue').html( data.earnings.total );
     $('#revenue-compare span').html( data.earnings.compare.percentage + compareTemp ).removeClass().addClass( data.earnings.compare.classes );
 
     $('#sales').html( data.sales.count );
     $('#sales-compare span').html( data.sales.compare.percentage + compareTemp ).removeClass().addClass( data.sales.compare.classes );
 
-    $('#yearly').html( eddm.currencySign + data.earnings.avgyearly.total );
+    $('#yearly').html( data.earnings.avgyearly.total );
     $('#avgyearly-compare span').html( data.earnings.avgyearly.compare.percentage + compareTemp ).removeClass().addClass( data.earnings.avgyearly.compare.classes );
 
-    $('#avgpercust').html( eddm.currencySign + data.earnings.avgpercust.total );
+    $('#avgpercust').html( data.earnings.avgpercust.total );
     $('#avgpercust-compare span').html( data.earnings.avgpercust.compare.percentage + compareTemp ).removeClass().addClass( data.earnings.avgpercust.compare.classes );
-    
+
   }
 
   eddm.batch2response = function(response) {
@@ -129,20 +128,20 @@
     var compareTemp = window.eddMetrics.compare_string + ' ' + data.dates.num_days + ' ' + window.eddMetrics.days;
 
     $('#renewals').html( data.renewals.count );
-    $('#renewal-amount').html( eddm.currencySign + data.renewals.earnings );
+    $('#renewal-amount').html( data.renewals.earnings );
     $('#renewals-compare span').html( data.renewals.compare.percentage + compareTemp ).removeClass().addClass( data.renewals.compare.classes );
 
     $('#refunds').html( data.refunds.count );
-    $('#refund-amount').html( eddm.currencySign + data.refunds.losses );
+    $('#refund-amount').html( data.refunds.losses );
     $('#refunds-compare span').html( data.refunds.compare.percentage + compareTemp ).removeClass().addClass( data.refunds.compare.classes );
 
     $('#subscriptions').html( data.subscriptions.count );
     $('#subscriptions-compare span').html( data.subscriptions.compare.percentage + compareTemp ).removeClass().addClass( data.subscriptions.compare.classes );
 
-    $('#discounts').html( eddm.currencySign + data.discounts.now.amount );
+    $('#discounts').html( data.discounts.now.amount );
     $('#discounts-count').html( data.discounts.now.count );
     $('#discounts-compare span').html( data.discounts.compare.percentage + compareTemp ).removeClass().addClass( data.discounts.compare.classes );
-    
+
   }
 
   eddm.detailResponse = function(response) {
@@ -150,24 +149,24 @@
     console.log( 'detailResponse', response );
 
     var data = JSON.parse(response);
-    
+
     var metric = eddm.getQueryVariable('metric');
 
     switch( metric ) {
       case 'revenue':
           // do revenue
 
-          $('#revenue').html( eddm.currencySign + data.earnings.total );
+          $('#revenue').html( data.earnings.total );
           $('#revenue-compare span').html( data.earnings.compare.percentage + eddm.compare_temp_2 ).removeClass().addClass( data.earnings.compare.classes );
-          $('.detail-compare-first').html( eddm.currencySign + data.earnings.compare.total );
+          $('.detail-compare-first').html( data.earnings.compare.total );
 
-          $('#monthly h2').html( eddm.currencySign + data.earnings.avgmonthly.earnings );
+          $('#monthly h2').html( data.earnings.avgmonthly.earnings );
 
           $('#new-customers h2').html( data.earnings.avgpercust.current_customers );
           $('#new-customers span').html( 'This period' );
 
           // // Charts
-          $('.detail-compare-first').html( eddm.currencySign + data.earnings.compare.total );
+          $('.detail-compare-first').html( data.earnings.compare.total );
           $('#box-4 .bottom-text span').html( data.earnings.compare.percentage + '%' );
 
           break;
@@ -181,7 +180,7 @@
     eddm.doLineChart( data.lineChart );
 
     $('.edd-metrics-chart-wrapper #circleG').remove();
-    
+
   }
 
   eddm.detailResponse_2 = function(response) {
@@ -189,7 +188,7 @@
     var data = JSON.parse(response);
 
     console.log( 'detailResponse_2', data );
-    
+
     var metric = eddm.getQueryVariable('metric');
 
     switch( metric ) {
@@ -197,21 +196,21 @@
           // do revenue
 
           $('#revenue-6mocompare span').text( data.earnings.detail.sixmoago.compare + eddm.compare_temp_2 ).removeClass().addClass( data.earnings.detail.sixmoago.classes );
-          $('.detail-compare-second').text( eddm.currencySign + data.earnings.detail.sixmoago.total );
+          $('.detail-compare-second').text( data.earnings.detail.sixmoago.total );
 
-          $('.detail-compare-third').text( eddm.currencySign + data.earnings.detail.twelvemoago.total );
+          $('.detail-compare-third').text( data.earnings.detail.twelvemoago.total );
           $('#revenue-12mocompare span').text( data.earnings.detail.twelvemoago.compare + eddm.compare_temp_2 ).removeClass().addClass( data.earnings.detail.twelvemoago.classes );
 
-          $('#earnings-today h2').text( eddm.currencySign + data.earnings.detail.today );
-          $('#earnings-this-month h2').text( eddm.currencySign + data.earnings.detail.this_month );
+          $('#earnings-today h2').text( data.earnings.detail.today );
+          $('#earnings-this-month h2').text( data.earnings.detail.this_month );
 
           $('#renewal-rate h2').text( data.yearly_renewal_rate.percent + '%' );
           $('#yearly-renewal-compare span').text( 'Last ' + data.yearly_renewal_rate.period + ' days' );
 
           $('#box-5 .bottom-text span').text( data.earnings.detail.sixmoago.compare + '%' );
-          $('.detail-compare-second').text( eddm.currencySign + data.earnings.detail.sixmoago.total );
+          $('.detail-compare-second').text( data.earnings.detail.sixmoago.total );
 
-          $('.detail-compare-third').text( eddm.currencySign + data.earnings.detail.twelvemoago.total );
+          $('.detail-compare-third').text( data.earnings.detail.twelvemoago.total );
 
           break;
       case 'renewals':

--- a/includes/class-edd-metrics-detail.php
+++ b/includes/class-edd-metrics-detail.php
@@ -95,15 +95,15 @@ if( !class_exists( 'EDD_Metrics_Detail' ) ) {
             $data['yearly_renewal_rate'] = self::get_yearly_renewal_rate();
 
             $data['earnings']['detail'] = array( 
-                'today' => number_format( $earnings_today, 2 ),
-                'this_month' => number_format( $earnings_this_month, 2 ),
+                'today' => edd_currency_filter( edd_format_amount( $earnings_today ) ),
+                'this_month' => edd_currency_filter( edd_format_amount( $earnings_this_month ) ),
                 'sixmoago' => array( 
-                    'total' => number_format( $earnings_6mo_ago, 2 ),
+                    'total' => edd_currency_filter( edd_format_amount( $earnings_6mo_ago ) ),
                     'compare' => self::get_percentage( $earnings, $earnings_6mo_ago ),
                     'classes' => $classes6mo
                     ),
                 'twelvemoago' => array( 
-                    'total' => number_format( $earnings_12mo_ago, 2 ),
+                    'total' => edd_currency_filter( edd_format_amount( $earnings_12mo_ago ) ),
                     'compare' => self::get_percentage( $earnings, $earnings_12mo_ago ),
                     'classes' => $classes12mo
                     ),
@@ -141,7 +141,7 @@ if( !class_exists( 'EDD_Metrics_Detail' ) ) {
 
             $percent = ( intval($renewals) / intval($sales) ) * 100;
 
-            return array( 'percent' => number_format( $percent, 2 ), 'period' => $period );
+            return array( 'percent' => edd_format_amount( $percent ), 'period' => $period );
         }
 
         /**

--- a/includes/class-edd-metrics-functions.php
+++ b/includes/class-edd-metrics-functions.php
@@ -180,11 +180,11 @@ if( !class_exists( 'EDD_Metrics_Functions' ) ) {
         	$classes = self::get_arrow_classes( $earnings, $previous_earnings );
 
         	return array( 
-                'total' => number_format( $earnings, 2 ), 
+                'total' => edd_currency_filter( edd_format_amount( $earnings ) ), 
                 'compare' => array( 
                     'classes' => $classes, 
                     'percentage' => self::get_percentage( $earnings, $previous_earnings ),
-                    'total' => number_format( $previous_earnings, 2 ) 
+                    'total' => edd_currency_filter( edd_format_amount( $previous_earnings ) ), 
                     ), 
                 'avgyearly' => self::get_avg_yearly( $earnings, $previous_earnings, $dates['num_days'] ), 
                 'avgpercust' => self::get_avg_percust( $earnings, $previous_earnings ),
@@ -225,7 +225,7 @@ if( !class_exists( 'EDD_Metrics_Functions' ) ) {
             $classes = self::get_arrow_classes( $total, $prev_total );
 
             return array( 
-                'total' => number_format( $total, 2 ),
+                'total' => edd_currency_filter( edd_format_amount( $total ) ),
                 'compare' => array( 
                     'classes' => $classes, 
                     'percentage' => self::get_percentage( $total, $prev_total ) 
@@ -269,7 +269,7 @@ if( !class_exists( 'EDD_Metrics_Functions' ) ) {
         public function get_avg_monthly() {
             $avg = edd_estimated_monthly_stats();
             return array(
-                'earnings' => number_format( $avg['earnings'], 2 ),
+                'earnings' => edd_currency_filter( edd_format_amount( $avg['earnings'] ) ),
                 'sales' => $avg['sales']
                 );
         }
@@ -301,7 +301,7 @@ if( !class_exists( 'EDD_Metrics_Functions' ) ) {
 			// output classes for arrows and colors
         	$classes = self::get_arrow_classes( $avgyearly, $previous_avgyearly );
 
-			return array( 'total' => number_format( $avgyearly, 2 ), 'compare' => array( 'classes' => $classes, 'percentage' => self::get_percentage( $avgyearly, $previous_avgyearly ) ) );
+			return array( 'total' => edd_currency_filter( edd_format_amount( $avgyearly ) ), 'compare' => array( 'classes' => $classes, 'percentage' => self::get_percentage( $avgyearly, $previous_avgyearly ) ) );
 
 		}
 
@@ -544,7 +544,7 @@ if( !class_exists( 'EDD_Metrics_Functions' ) ) {
 
             return array( 
                 'count' => $count, 
-                'earnings' => number_format( $earnings, 2 )
+                'earnings' => edd_currency_filter( edd_format_amount( $earnings ) ),
                 );
         }
 
@@ -640,7 +640,7 @@ if( !class_exists( 'EDD_Metrics_Functions' ) ) {
                 return array( 'amount' => 0, 'count' => 0 );
             }
 
-            return array( 'amount' => number_format( $amount, 2 ), 'count' => $count
+            return array( 'amount' => edd_currency_filter( edd_format_amount( $amount ) ), 'count' => $count
                 );
         }
 
@@ -722,7 +722,7 @@ if( !class_exists( 'EDD_Metrics_Functions' ) ) {
                 $compare = self::compare_refunds( $refunds['count'] );
             }
 
-			return array( 'count' => $refunds['count'], 'losses' => number_format( $refunds['earnings'], 2 ), 'compare' => $compare );
+			return array( 'count' => $refunds['count'], 'losses' => edd_currency_filter( edd_format_amount( $refunds['earnings'] ) ), 'compare' => $compare );
 	    }
 
         /**


### PR DESCRIPTION
By using the standard edd_currency_filter() and edd_format_amount() functions the currency numbers are formatted with the EDD settings for currencies. This includes currency position, thousands separator and decimal separator (Currency Settings can be found on EDD > Settings > General > Currency Settings).

The first commit removes the hard coded currency sign in the admin.js. I have not minified the admin.min.js, so this has to be done before the next release. 