### PR TITLE
Fixing undefined currency on commissions box

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -148,7 +148,7 @@
 
     if( $('#commissions').length ) {
       $('#commissions').html( data.commissions.count );
-      $('#commissions-amount').html( eddm.currencySign + data.commissions.earnings );
+      $('#commissions-amount').html( data.commissions.earnings );
     }
 
   }

--- a/includes/class-edd-metrics-functions.php
+++ b/includes/class-edd-metrics-functions.php
@@ -608,7 +608,7 @@ if( !class_exists( 'EDD_Metrics_Functions' ) ) {
             }
 
             $commissions['count'] = count( eddc_get_unpaid_commissions( $args = array() ) );
-            $commissions['earnings'] = edd_format_amount( eddc_get_unpaid_totals( 0 ) );
+            $commissions['earnings'] = edd_currency_filter( edd_format_amount( eddc_get_unpaid_totals( 0 ) ) );
 
             return $commissions;
 


### PR DESCRIPTION
Fixes #37 by using edd_currency_filter() around commissions earnings instead of hard coded currency.

The eddm.currencySign was removed from admin.js.  This will need a rebuild of the .min file. 
