### PR TITLE
Fix PHP parser error

### DIFF
--- a/includes/class-edd-metrics-functions.php
+++ b/includes/class-edd-metrics-functions.php
@@ -294,7 +294,8 @@ if( !class_exists( 'EDD_Metrics_Functions' ) ) {
         	}
 
         	// Yearly estimate - avg rev per day in set time period, averaged out over 365 days. So $287/day in the last 30 days would be $287*365
-			$num_days = self::get_compare_dates()['num_days'];
+		$comp_dates = self::get_compare_dates();
+		$num_days = $comp_dates['num_days'];		
 
 			$avgyearly = ( $earnings/$num_days )*365;
 			$previous_avgyearly = ( $previous_earnings/$num_days )*365;


### PR DESCRIPTION
I am getting this error: 
```
PHP Parse error:  syntax error, unexpected '[' in /path/to/wp/wp-content/plugins/edd-metrics/includes/class-edd-metrics-functions.php on line 297
```
I'm on PHP7, so wondering if this might be a syntax error related to that. This PR resolves the issue.