### PR TITLE
Sanitize the numbers passed to percent_change

### DIFF
--- a/includes/class-edd-metrics-functions.php
+++ b/includes/class-edd-metrics-functions.php
@@ -383,6 +383,9 @@ if( !class_exists( 'EDD_Metrics_Functions' ) ) {
          */
         public static function percent_change($new_val, $old_val) {
 
+	    $new_val = edd_sanitize_amount( $new_val );
+            $old_val = edd_sanitize_amount( $old_val );
+		
             if( empty( $old_val ) || $old_val === 0 )
                 return 0;
 


### PR DESCRIPTION
This prevents calculations on values that may contain dollar signs and commas.

The `get_percentage()` method was returning a NaN value, which can't be JSON-encoded. `json_encode()` was returning `JSON_ERROR_INF_OR_NAN`. This fixes that, and the broken AJAX request.

Fixes #35