### PR TITLE
Get correct revenue figures for historical data (e.g. last year)

### DIFF
--- a/includes/class-edd-metrics-functions.php
+++ b/includes/class-edd-metrics-functions.php
@@ -939,7 +939,7 @@ if( !class_exists( 'EDD_Metrics_Functions' ) ) {
          */
         public static function get_net_revenue( $start, $end ) {
 
-            $twomoago = date( "jS F Y", strtotime( "-2 months" ) );
+            $twomoago = date( "jS F Y", strtotime( "-2 months", $start ) );
             
             $EDD_Stats = new EDD_Payment_Stats();
             $earnings_then = $EDD_Stats->get_earnings( 0, $twomoago, date( "jS F Y", $start ) );


### PR DESCRIPTION
$twomoago in get_net_revenue was giving a start date later than the end date in many historical cases, because it was based on today's date. It is now set two months before the start date of the period in question, allowing it to take into account refunds.