### PR TITLE
Adding URL to Boxy Studio GitHub account

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Install and activate this plugin on your WordPress site, then visit the "Metrics
 
 =1.0=
 
-* Major UI update thanks to @boxystudio!
+* Major UI update thanks to [@boxystudio](https://github.com/boxystudio)!
 
 =0.6=
 


### PR DESCRIPTION
I saw that @boxystudio gets a shoutout in the README file, but that no link is included. Decided to fix that.